### PR TITLE
name fix for _get_obs in env_wrapper.jl

### DIFF
--- a/src/Envs/env_wrapper.jl
+++ b/src/Envs/env_wrapper.jl
@@ -37,9 +37,20 @@ function reset!(env::EnvWrapper)
     reset!(env._env)
 end
 
-getobs(env::AbstractEnv) = env.state
+"""
+Returns the observational state of the environment. The original state can
+be accessed by `\`env._env.state\``.
+"""
+function state(env::EnvWrapper)
+	try
+		return _get_obs(env._env)
+	catch y
+		if isa(y, UndefVarError) || isa(y, MethodError)
+			return env._env.state
+		end
+	end
+end
 
-state(env::EnvWrapper) = getobs(env._env)
 
 function testmode!(env::EnvWrapper, val::Bool=true)
     env.train = !val

--- a/src/Envs/env_wrapper.jl
+++ b/src/Envs/env_wrapper.jl
@@ -15,8 +15,8 @@ mutable struct EnvWrapper
     _env::AbstractEnv
 end
 
-EnvWrapper(env::AbstractEnv, train::Bool=true; 
-		   reward_threshold=nothing, max_episode_steps=nothing) = 
+EnvWrapper(env::AbstractEnv, train::Bool=true;
+		   reward_threshold=nothing, max_episode_steps=nothing) =
 EnvWrapper(false, 0, 0, train, reward_threshold, max_episode_steps, env)
 
 function step!(env::EnvWrapper, a)
@@ -37,9 +37,9 @@ function reset!(env::EnvWrapper)
     reset!(env._env)
 end
 
-_get_obs(env::AbstractEnv) = env.state
+getobs(env::AbstractEnv) = env.state
 
-state(env::EnvWrapper) = _get_obs(env._env)
+state(env::EnvWrapper) = getobs(env._env)
 
 function testmode!(env::EnvWrapper, val::Bool=true)
     env.train = !val


### PR DESCRIPTION
Currently, there are two definitions of `_get_obs`...

- `_get_obs(::AbstractEnv)` used by `state(::EnvWrapper)`

- `_get_obs(::PendulumEnv)` which is a utility function used by the Pendulum Environment.

So when we create a PendulumEnv, and call `state()` against it, the function calls `_get_obs(::PendulumEnv)` instead of `_get_obs(::AbstractEnv)`, since `PendulumEnv` is a subtype of `AbstractEnv`. This PR changes `_get_obs(::AbstractEnv)` to `getobs(::AbstractEnv)`.