### PR TITLE
Minor error not using Images, Colors in vis/utils.jl.

### DIFF
--- a/src/Envs/vis/utils.jl
+++ b/src/Envs/vis/utils.jl
@@ -1,4 +1,4 @@
-using Cairo, Gtk
+using Cairo, Gtk, Images, Colors
 
 abstract type AbstractCtx end
 abstract type AbstractDrawParams end


### PR DESCRIPTION
RGB mode isn't working because some packages were not imported in `vis/utils.jl`. This is a small fix.